### PR TITLE
引用符のスタイルを英語に戻す

### DIFF
--- a/docutils.conf
+++ b/docutils.conf
@@ -1,0 +1,2 @@
+[parsers]
+smartquotes_locales: ja: “”‘’


### PR DESCRIPTION
日本語ドキュメントでは、文中の引用符 `"` ／ `'` はビルドすると、 `「`, `」` ／ `『`, `』`に変換されますが、変換されてしまうと読みづらく感じる箇所があるかと思います。(英単語・英文のところはとくに)
そこで、引用符がローカライズされないようにできたので、プルリクします。

## 変更前

http://phpunit.readthedocs.io/ja/latest/test-doubles.html#test-doubles-stubs コラム

<img width="457" alt="2018-07-15 16 11 08" src="https://user-images.githubusercontent.com/16202/42731563-aa69e9fe-884a-11e8-847a-21a32f39e069.png">

## 変更後

<img width="468" alt="2018-07-15 16 11 38" src="https://user-images.githubusercontent.com/16202/42731572-d0c01736-884a-11e8-9e8f-1a32286dd412.png">
