### PR TITLE
[testui.rst] fix Japanese translation typo

### DIFF
--- a/src/textui.rst
+++ b/src/textui.rst
@@ -299,7 +299,7 @@ PHPUnit は、*失敗 (failures)* と
         --filter 'TestNamespace\\TestCaseClass::testMethod'
         --filter 'TestNamespace\\TestCaseClass'
         --filter TestNamespace
-        --filter TestCaseClase
+        --filter TestCaseClass
         --filter testMethod
         --filter '/::testMethod .*"my named data"/'
         --filter '/::testMethod .*#5$/'


### PR DESCRIPTION
### 変更内容

原文 ( https://phpunit.readthedocs.io/en/9.5/textui.html ) の下記

```
Example 3.2 Filter pattern examples
--filter 'TestNamespace\\TestCaseClass::testMethod'
--filter 'TestNamespace\\TestCaseClass'
--filter TestNamespace
--filter TestCaseClass
--filter testMethod
--filter '/::testMethod .*"my named data"/'
--filter '/::testMethod .*#5$/'
--filter '/::testMethod .*#(5|6|7)$/'
```

を確認し、日本語版の typo を修正しました。
