### PR TITLE
change beStrictAboutTestSize to enforceTimeLimit

### DIFF
--- a/src/risky-tests.rst
+++ b/src/risky-tests.rst
@@ -70,7 +70,7 @@ PHPUnit は、テストの最中の出力を検出することができます。
 :ref:`コマンドライン <textui.clioptions>` オプション
 ``--enforce-time-limit`` を使うか、あるいは PHPUnit の
 :ref:`設定ファイル <appendixes.configuration>` で
-``beStrictAboutTestSize="true"`` を設定します。
+``enforceTimeLimit="true"`` を設定します。
 
 ``@large`` とマークされたテストは、
 実行時間が 60 秒を超えたら失敗します。


### PR DESCRIPTION
This PR fixes old configuration name `beStrictAboutTestSize` to `enforceTimeLimit`.
English version: https://github.com/sebastianbergmann/phpunit-documentation-english/blob/c0e7a5742cbc7bb776934aa47fd0cc10311fb52f/src/risky-tests.rst#L74